### PR TITLE
dev, scheduler, ahci, dev: Refactor scheduler, and fix minor mistakes.

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -10,13 +10,12 @@
 -Ipublic/frameworks
 -Idev/boot/BootKit
 -std=c++20
--D__NE_AMD64__
+-D__NE_ARM64__
 -D__NEOSKRNL__
 -D__FSKIT_INCLUDES_NEFS__
 -D__NE_ED__
 -xc++
 -D__AHCI__
--D__x86_64__
 -D__aarch64__
 -DNE_USE_MBCI_FLASH
 -D__ATA_DMA__

--- a/dev/kernel/FirmwareKit/GPT.h
+++ b/dev/kernel/FirmwareKit/GPT.h
@@ -10,6 +10,7 @@
 #include <FirmwareKit/EFI/EFI.h>
 
 #define kSectorSizeGPT (512U)
+#define kPartNameGPT (8U)
 
 namespace Kernel
 {
@@ -28,7 +29,7 @@ namespace Kernel
 
 	struct PACKED GPT_PARTITION_TABLE final
 	{
-		Char	 PartitionName[8];
+		Char	 PartitionName[kPartNameGPT];
 		UInt32	 Revision;
 		UInt32	 HeaderSize;
 		UInt32	 ChecksumCRC32;

--- a/dev/kernel/HALKit/AMD64/HalKernelMain.cc
+++ b/dev/kernel/HALKit/AMD64/HalKernelMain.cc
@@ -22,7 +22,7 @@ STATIC Kernel::Void hal_init_scheduler_team()
 {
 	for (Kernel::SizeT i = 0U; i < Kernel::UserProcessScheduler::The().CurrentTeam().AsArray().Count(); ++i)
 	{
-		Kernel::UserProcessScheduler::The().CurrentTeam().AsArray()[i]		  = Kernel::UserProcess();
+		Kernel::UserProcessScheduler::The().CurrentTeam().AsArray()[i]		  = Kernel::Process();
 		Kernel::UserProcessScheduler::The().CurrentTeam().AsArray()[i].Status = Kernel::ProcessStatusKind::kKilled;
 	}
 }

--- a/dev/kernel/HALKit/AMD64/HalSchedulerCorePrimitivesAMD64.cc
+++ b/dev/kernel/HALKit/AMD64/HalSchedulerCorePrimitivesAMD64.cc
@@ -14,7 +14,7 @@ namespace Kernel
 	/// @param
 	/***********************************************************************************/
 
-	EXTERN_C Void __zka_pure_call(UserProcess* process)
+	EXTERN_C Void __zka_pure_call(Process* process)
 	{
 		if (process)
 			process->Crash();

--- a/dev/kernel/HALKit/ARM64/HalSchedulerCorePrimitivesARM64.cc
+++ b/dev/kernel/HALKit/ARM64/HalSchedulerCorePrimitivesARM64.cc
@@ -14,7 +14,7 @@ namespace Kernel
 	/// @param void
 	/***********************************************************************************/
 
-	EXTERN_C Void __zka_pure_call(UserProcess* process)
+	EXTERN_C Void __zka_pure_call(Process* process)
 	{
 		if (process)
 			process->Crash();

--- a/dev/kernel/KernelKit/BinaryMutex.h
+++ b/dev/kernel/KernelKit/BinaryMutex.h
@@ -12,9 +12,9 @@
 
 namespace Kernel
 {
-	class UserProcess;
+	class Process;
 
-	typedef UserProcess& UserProcessRef;
+	typedef Process& UserProcessRef;
 
 	/// @brief Access control class, which locks a task until one is done.
 	class BinaryMutex final
@@ -31,8 +31,8 @@ namespace Kernel
 		BOOL WaitForProcess(const Int16& sec) noexcept;
 
 	public:
-		bool Lock(UserProcess& process);
-		bool LockOrWait(UserProcess& process, TimerInterface* timer);
+		bool Lock(Process& process);
+		bool LockOrWait(Process& process, TimerInterface* timer);
 
 	public:
 		NE_COPY_DEFAULT(BinaryMutex)

--- a/dev/kernel/KernelKit/Defines.h
+++ b/dev/kernel/KernelKit/Defines.h
@@ -13,4 +13,4 @@
 
 class UserProcessScheduler;
 class IDylibObject;
-class UserProcess;
+class Process;

--- a/dev/kernel/KernelKit/DeviceMgr.h
+++ b/dev/kernel/KernelKit/DeviceMgr.h
@@ -52,13 +52,13 @@ namespace Kernel
 		IDeviceObject(const IDeviceObject<T>&)			  = default;
 
 	public:
-		virtual IDeviceObject<T>& operator<<(T Data) [[maybe_unused]]
+		virtual IDeviceObject<T>& operator<<(T Data) 
 		{
 			fOut(this, Data);
 			return *this;
 		}
 
-		virtual IDeviceObject<T>& operator>>(T Data) [[maybe_unused]]
+		virtual IDeviceObject<T>& operator>>(T Data) 
 		{
 			fIn(this, Data);
 			return *this;
@@ -133,6 +133,7 @@ namespace Kernel
 		kDeviceTypeSCSI,
 		kDeviceTypeAHCI,
 		kDeviceTypeMBCI,
+		kDeviceTypeATA,
 		kDeviceTypeUSB,
 		kDeviceTypeMediaCtrl, // MM controller
 		kDeviceTypeCount,

--- a/dev/kernel/KernelKit/IPEFDylibObject.h
+++ b/dev/kernel/KernelKit/IPEFDylibObject.h
@@ -99,8 +99,8 @@ namespace Kernel
 
 	typedef IPEFDylibObject* IDylibRef;
 
-	EXTERN_C IDylibRef rtl_init_dylib(UserProcess& header);
-	EXTERN_C Void	   rtl_fini_dylib(UserProcess& header, IDylibRef lib, Bool* successful);
+	EXTERN_C IDylibRef rtl_init_dylib(Process& header);
+	EXTERN_C Void	   rtl_fini_dylib(Process& header, IDylibRef lib, Bool* successful);
 } // namespace Kernel
 
 #endif /* ifndef __KERNELKIT_SHARED_OBJECT_H__ */

--- a/dev/kernel/KernelKit/PEF.h
+++ b/dev/kernel/KernelKit/PEF.h
@@ -21,10 +21,10 @@
 #define kPefMagic	 "Joy!"
 #define kPefMagicFat "yoJ!"
 
-#define kPefMagicLen 5
+#define kPefMagicLen (5)
 
-#define kPefVersion 3
-#define kPefNameLen 256U
+#define kPefVersion (3)
+#define kPefNameLen (256U)
 
 /* not mandatory, only for non fork based filesystems. */
 #define kPefExt		  ".exec"

--- a/dev/kernel/KernelKit/UserProcessScheduler.inl
+++ b/dev/kernel/KernelKit/UserProcessScheduler.inl
@@ -17,7 +17,7 @@ namespace Kernel
 	/***********************************************************************************/
 
 	template <typename T>
-	Boolean UserProcess::Delete(ErrorOr<T*> ptr)
+	Boolean Process::Delete(ErrorOr<T*> ptr)
 	{
 		if (!ptr)
 			return No;

--- a/dev/kernel/NetworkKit/IPC.h
+++ b/dev/kernel/NetworkKit/IPC.h
@@ -34,7 +34,7 @@ namespace Kernel
 	struct PACKED IPC_ADDR final
 	{
 		UInt64 UserProcessID;
-		UInt64 UserProcessTeam;
+		UInt64 ProcessTeam;
 
 		////////////////////////////////////
 		// some operators.

--- a/dev/kernel/src/BinaryMutex.cc
+++ b/dev/kernel/src/BinaryMutex.cc
@@ -16,7 +16,7 @@ namespace Kernel
 	{
 		if (fLockingProcess)
 		{
-			fLockingProcess		   = UserProcess();
+			fLockingProcess		   = Process();
 			fLockingProcess.Status = ProcessStatusKind::kFrozen;
 			return Yes;
 		}
@@ -27,7 +27,7 @@ namespace Kernel
 	/***********************************************************************************/
 	/// @brief Locks process in the semaphore.
 	/***********************************************************************************/
-	Bool BinaryMutex::Lock(UserProcess& process)
+	Bool BinaryMutex::Lock(Process& process)
 	{
 		if (!process || fLockingProcess)
 			return No;
@@ -48,7 +48,7 @@ namespace Kernel
 	/***********************************************************************************/
 	/// @brief Try lock or wait.
 	/***********************************************************************************/
-	Bool BinaryMutex::LockOrWait(UserProcess& process, TimerInterface* timer)
+	Bool BinaryMutex::LockOrWait(Process& process, TimerInterface* timer)
 	{
 		if (timer == nullptr)
 			return No;

--- a/dev/kernel/src/IPEFDylibObject.cc
+++ b/dev/kernel/src/IPEFDylibObject.cc
@@ -41,7 +41,7 @@ using namespace Kernel;
 /** @brief Library initializer. */
 /***********************************************************************************/
 
-EXTERN_C IDylibRef rtl_init_dylib(UserProcess& process)
+EXTERN_C IDylibRef rtl_init_dylib(Process& process)
 {
 	IDylibRef dll_obj = tls_new_class<IPEFDylibObject>();
 
@@ -91,7 +91,7 @@ EXTERN_C IDylibRef rtl_init_dylib(UserProcess& process)
 /** @param successful Reports if successful or not. */
 /***********************************************************************************/
 
-EXTERN_C Void rtl_fini_dylib(UserProcess& process, IDylibRef dll_obj, BOOL* successful)
+EXTERN_C Void rtl_fini_dylib(Process& process, IDylibRef dll_obj, BOOL* successful)
 {
 	MUST_PASS(successful);
 

--- a/dev/kernel/src/Network/IPCAddr.cc
+++ b/dev/kernel/src/Network/IPCAddr.cc
@@ -12,21 +12,21 @@ namespace Kernel
 {
 	bool IPC_ADDR::operator==(const IPC_ADDR& addr) noexcept
 	{
-		return addr.UserProcessID == this->UserProcessID && addr.UserProcessTeam == this->UserProcessTeam;
+		return addr.UserProcessID == this->UserProcessID && addr.ProcessTeam == this->ProcessTeam;
 	}
 
 	bool IPC_ADDR::operator==(IPC_ADDR& addr) noexcept
 	{
-		return addr.UserProcessID == this->UserProcessID && addr.UserProcessTeam == this->UserProcessTeam;
+		return addr.UserProcessID == this->UserProcessID && addr.ProcessTeam == this->ProcessTeam;
 	}
 
 	bool IPC_ADDR::operator!=(const IPC_ADDR& addr) noexcept
 	{
-		return addr.UserProcessID != this->UserProcessID || addr.UserProcessTeam != this->UserProcessTeam;
+		return addr.UserProcessID != this->UserProcessID || addr.ProcessTeam != this->ProcessTeam;
 	}
 
 	bool IPC_ADDR::operator!=(IPC_ADDR& addr) noexcept
 	{
-		return addr.UserProcessID != this->UserProcessID || addr.UserProcessTeam != this->UserProcessTeam;
+		return addr.UserProcessID != this->UserProcessID || addr.ProcessTeam != this->ProcessTeam;
 	}
 } // namespace Kernel

--- a/dev/kernel/src/Network/IPCMsg.cc
+++ b/dev/kernel/src/Network/IPCMsg.cc
@@ -91,10 +91,10 @@ namespace Kernel
 			(*pckt_in)->IpcPacketSize = sizeof(IPC_MSG);
 
 			(*pckt_in)->IpcTo.UserProcessID	  = 0;
-			(*pckt_in)->IpcTo.UserProcessTeam = 0;
+			(*pckt_in)->IpcTo.ProcessTeam = 0;
 
 			(*pckt_in)->IpcFrom.UserProcessID	= 0;
-			(*pckt_in)->IpcFrom.UserProcessTeam = 0;
+			(*pckt_in)->IpcFrom.ProcessTeam = 0;
 
 			return Yes;
 		}

--- a/dev/kernel/src/ProcessTeam.cc
+++ b/dev/kernel/src/ProcessTeam.cc
@@ -5,7 +5,7 @@
 ------------------------------------------- */
 
 /***********************************************************************************/
-/// @file UserProcessTeam.cc
+/// @file ProcessTeam.cc
 /// @brief Process teams implementation.
 /***********************************************************************************/
 
@@ -13,11 +13,11 @@
 
 namespace Kernel
 {
-	UserProcessTeam::UserProcessTeam()
+	ProcessTeam::ProcessTeam()
 	{
 		for (SizeT i = 0U; i < this->mProcessList.Count(); ++i)
 		{
-			this->mProcessList[i]		 = UserProcess();
+			this->mProcessList[i]		 = Process();
 			this->mProcessList[i].PTime	 = 0;
 			this->mProcessList[i].Status = ProcessStatusKind::kKilled;
 		}
@@ -26,11 +26,11 @@ namespace Kernel
 	}
 
 	/***********************************************************************************/
-	/// @brief UserProcess list array getter.
+	/// @brief Process list array getter.
 	/// @return The list of process to schedule.
 	/***********************************************************************************/
 
-	Array<UserProcess, kSchedProcessLimitPerTeam>& UserProcessTeam::AsArray()
+	Array<Process, kSchedProcessLimitPerTeam>& ProcessTeam::AsArray()
 	{
 		return this->mProcessList;
 	}
@@ -40,7 +40,7 @@ namespace Kernel
 	/// @return The team's ID.
 	/***********************************************************************************/
 
-	ProcessID& UserProcessTeam::Id() noexcept
+	ProcessID& ProcessTeam::Id() noexcept
 	{
 		return this->mTeamId;
 	}
@@ -50,7 +50,7 @@ namespace Kernel
 	/// @return The current process header.
 	/***********************************************************************************/
 
-	Ref<UserProcess>& UserProcessTeam::AsRef()
+	Ref<Process>& ProcessTeam::AsRef()
 	{
 		return this->mCurrentProcess;
 	}

--- a/dev/kernel/src/UserProcessScheduler.cc
+++ b/dev/kernel/src/UserProcessScheduler.cc
@@ -37,8 +37,8 @@ namespace Kernel
 
 	STATIC UserProcessScheduler kProcessScheduler;
 
-	UserProcess::UserProcess()	= default;
-	UserProcess::~UserProcess() = default;
+	Process::Process()	= default;
+	Process::~Process() = default;
 
 	/// @brief Gets the last exit code.
 	/// @note Not thread-safe.
@@ -53,7 +53,7 @@ namespace Kernel
 	/// @brief Crashes the current process.
 	/***********************************************************************************/
 
-	Void UserProcess::Crash()
+	Void Process::Crash()
 	{
 		if (this->Status != ProcessStatusKind::kRunning)
 			return;
@@ -66,7 +66,7 @@ namespace Kernel
 	/// @brief boolean operator, check status.
 	/***********************************************************************************/
 
-	UserProcess::operator bool()
+	Process::operator bool()
 	{
 		return this->Status == ProcessStatusKind::kRunning;
 	}
@@ -77,7 +77,7 @@ namespace Kernel
 	/// @return Int32 the last exit code.
 	/***********************************************************************************/
 
-	const UInt32& UserProcess::GetExitCode() noexcept
+	const UInt32& Process::GetExitCode() noexcept
 	{
 		return this->fLastExitCode;
 	}
@@ -86,7 +86,7 @@ namespace Kernel
 	/// @brief Error code variable getter.
 	/***********************************************************************************/
 
-	Int32& UserProcess::GetLocalCode() noexcept
+	Int32& Process::GetLocalCode() noexcept
 	{
 		return this->fLocalCode;
 	}
@@ -96,7 +96,7 @@ namespace Kernel
 	/// @param should_wakeup if the program shall wakeup or not.
 	/***********************************************************************************/
 
-	Void UserProcess::Wake(Bool should_wakeup)
+	Void Process::Wake(Bool should_wakeup)
 	{
 		this->Status =
 			should_wakeup ? ProcessStatusKind::kRunning : ProcessStatusKind::kFrozen;
@@ -106,7 +106,7 @@ namespace Kernel
 	/** @brief Allocate pointer to track list. */
 	/***********************************************************************************/
 
-	ErrorOr<VoidPtr> UserProcess::New(SizeT sz, SizeT pad_amount)
+	ErrorOr<VoidPtr> Process::New(SizeT sz, SizeT pad_amount)
 	{
 #ifdef __NE_VIRTUAL_MEMORY_SUPPORT__
 		auto vm_register = hal_read_cr3();
@@ -159,7 +159,7 @@ namespace Kernel
 	/// @brief Gets the name of the current process.
 	/***********************************************************************************/
 
-	const Char* UserProcess::GetName() noexcept
+	const Char* Process::GetName() noexcept
 	{
 		return this->Name;
 	}
@@ -168,13 +168,13 @@ namespace Kernel
 	/// @brief Gets the owner of the process.
 	/***********************************************************************************/
 
-	const User* UserProcess::GetOwner() noexcept
+	const User* Process::GetOwner() noexcept
 	{
 		return this->Owner;
 	}
 
-	/// @brief UserProcess status getter.
-	const ProcessStatusKind& UserProcess::GetStatus() noexcept
+	/// @brief Process status getter.
+	const ProcessStatusKind& Process::GetStatus() noexcept
 	{
 		return this->Status;
 	}
@@ -185,7 +185,7 @@ namespace Kernel
 	*/
 	/***********************************************************************************/
 
-	const AffinityKind& UserProcess::GetAffinity() noexcept
+	const AffinityKind& Process::GetAffinity() noexcept
 	{
 		return this->Affinity;
 	}
@@ -197,7 +197,7 @@ namespace Kernel
 	*/
 	/***********************************************************************************/
 
-	Void UserProcess::Exit(const Int32& exit_code)
+	Void Process::Exit(const Int32& exit_code)
 	{
 		this->Status		= exit_code > 0 ? ProcessStatusKind::kKilled : ProcessStatusKind::kFrozen;
 		this->fLastExitCode = exit_code;
@@ -294,7 +294,7 @@ namespace Kernel
 
 		++this->mTeam.mProcessCount;
 
-		UserProcess& process = this->mTeam.mProcessList[pid];
+		Process& process = this->mTeam.mProcessList[pid];
 
 		process.Image.fCode = code;
 		process.Image.fBlob = image;
@@ -336,7 +336,7 @@ namespace Kernel
 		// React according to process kind.
 		switch (process.Kind)
 		{
-		case UserProcess::kExectuableDylibKind: {
+		case Process::kExectuableDylibKind: {
 			process.DylibDelegate = rtl_init_dylib(process);
 			MUST_PASS(process.DylibDelegate);
 			break;
@@ -472,7 +472,7 @@ namespace Kernel
 
 	/// @brief Gets the current scheduled team.
 	/// @return
-	UserProcessTeam& UserProcessScheduler::CurrentTeam()
+	ProcessTeam& UserProcessScheduler::CurrentTeam()
 	{
 		return mTeam;
 	}
@@ -481,13 +481,13 @@ namespace Kernel
 
 	/// @brief Gets current running process.
 	/// @return
-	Ref<UserProcess>& UserProcessScheduler::CurrentProcess()
+	Ref<Process>& UserProcessScheduler::CurrentProcess()
 	{
 		return mTeam.AsRef();
 	}
 
 	/// @brief Current proccess id getter.
-	/// @return UserProcess ID integer.
+	/// @return Process ID integer.
 	ErrorOr<PID> UserProcessHelper::TheCurrentPID()
 	{
 		if (!kProcessScheduler.CurrentProcess())
@@ -501,7 +501,7 @@ namespace Kernel
 	/// @param process the process reference.
 	/// @retval true can be schedulded.
 	/// @retval false cannot be schedulded.
-	Bool UserProcessHelper::CanBeScheduled(const UserProcess& process)
+	Bool UserProcessHelper::CanBeScheduled(const Process& process)
 	{
 		if (process.Status == ProcessStatusKind::kKilled ||
 			process.Status == ProcessStatusKind::kFinished ||

--- a/docs/drawio/SOFT_SCHED_DESIGN.drawio
+++ b/docs/drawio/SOFT_SCHED_DESIGN.drawio
@@ -10,10 +10,10 @@
                 <mxCell id="ifhO3zQZNW-sXvZMTmu8-3" value="Running code (RING 3)" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
                     <mxGeometry x="235.5" y="295" width="360" height="35" as="geometry"/>
                 </mxCell>
-                <mxCell id="ifhO3zQZNW-sXvZMTmu8-8" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;NeKernel Scheduler&lt;/span&gt;&lt;/h1&gt;&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;&lt;span style=&quot;font-size: 12px; font-weight: 400; background-color: initial;&quot;&gt;This describes how NeKernel is structued to schedule tasks.&lt;/span&gt;&lt;br&gt;&lt;/h1&gt;&lt;div&gt;A UserProcess may be attached to another one (thread)&lt;/div&gt;&lt;div&gt;Otherwise it's a process within a team.&lt;/div&gt;" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" parent="1" vertex="1">
+                <mxCell id="ifhO3zQZNW-sXvZMTmu8-8" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;NeKernel Scheduler&lt;/span&gt;&lt;/h1&gt;&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;&lt;span style=&quot;font-size: 12px; font-weight: 400; background-color: initial;&quot;&gt;This describes how NeKernel is structued to schedule tasks.&lt;/span&gt;&lt;br&gt;&lt;/h1&gt;&lt;div&gt;A Process may be attached to another one (thread)&lt;/div&gt;&lt;div&gt;Otherwise it's a process within a team.&lt;/div&gt;" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" parent="1" vertex="1">
                     <mxGeometry x="620" y="290" width="180" height="200" as="geometry"/>
                 </mxCell>
-                <mxCell id="ifhO3zQZNW-sXvZMTmu8-13" value="UserProcess structure (RING 0)" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                <mxCell id="ifhO3zQZNW-sXvZMTmu8-13" value="Process structure (RING 0)" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
                     <mxGeometry x="235.5" y="380" width="360" height="60" as="geometry"/>
                 </mxCell>
                 <mxCell id="4" value="HardwareThread, HardwareThreadScheduler and UserProcessScheduler (RING 0)" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">


### PR DESCRIPTION
Add kDeviceTypeATA in DeviceMgr.h, making NeKernel aware that ATA devices can exist too.

The scheduler now won't have to reimplement new classes, I refactor the names to signal that, and they're already generic enough to signal that.

The AHCI-Generic driver got cleaned up of any irrelevant code, such as aligning the newly allocated pointer.